### PR TITLE
fix(docs): landing page broken layout and animation

### DIFF
--- a/apps/docs/src/app/pages/landing/landing-page.component.html
+++ b/apps/docs/src/app/pages/landing/landing-page.component.html
@@ -94,8 +94,8 @@
 					employees has grown into an active open source ecosystem powered by the
 					ingenuity of our team and the broader developer community.
 				</p>
-				<div #photo class="photo">
-					<div [@slideIn]="clipPhotoLine ? 'hide' : 'show'" class="line"></div>
+				<div class="photo" #photo>
+					<div class="line" [class.expanded]="clipPhotoLine"></div>
 				</div>
 				<p class="extra-margin">
 					Since the launch in <b>2021</b>, we’ve already created <b>16 packages</b> for
@@ -155,14 +155,14 @@
 					for Angular applications, our packages have something to offer. And if not, stay
 					tuned. We’re working every day on expanding them.
 				</p>
-				<div #quote class="quote">
+				<div class="quote" #quote>
 					<p>
 						“By switching our mindset from one-off to more robust solutions, we are now
 						working together across projects, which has had a remarkable impact on the
 						quality of our code and developer happiness.”
 					</p>
 					<cite>Denis Valcke, lead developer and project founder.</cite>
-					<div [@slideIn]="clipQuoteLine ? 'hide' : 'show'" class="line"></div>
+					<div class="line" [class.expanded]="clipQuoteLine"></div>
 				</div>
 			</div>
 		</section>

--- a/apps/docs/src/app/pages/landing/landing-page.component.scss
+++ b/apps/docs/src/app/pages/landing/landing-page.component.scss
@@ -56,6 +56,7 @@ div.landing {
 			max-width: 1024px;
 			padding: 0 1rem;
 			margin: auto;
+			display: grid;
 			h1 {
 				margin: 4rem 0 4rem 0;
 				font-size: 2.8rem;
@@ -65,9 +66,6 @@ div.landing {
 				}
 			}
 			h2 {
-				justify-self: end;
-				padding: 0 1rem;
-				align-self: start;
 				font-size: 1.4rem;
 				margin-bottom: 4rem;
 			}
@@ -153,6 +151,10 @@ div.landing {
 							#38cfff 51.04%,
 							#f872c2 98.69%
 						);
+						clip-path: inset(0 100% 0 0);
+						transition: clip-path 1s ease-in-out 50ms;
+					}
+					div.expanded {
 						clip-path: inset(0 0 0 0);
 					}
 				}
@@ -206,7 +208,9 @@ div.landing {
 							height: 1.5rem;
 							display: block;
 							padding: 0.25rem 0.5rem;
-							transition: background-color 0.3s, border 0.3s;
+							transition:
+								background-color 0.3s,
+								border 0.3s;
 							img {
 								display: block;
 								width: 100%;
@@ -246,6 +250,8 @@ div.landing {
 					}
 				}
 				h2 {
+					padding: 0 1rem;
+					justify-self: end;
 					width: 75%;
 					margin-bottom: 6rem;
 					text-align: right;

--- a/apps/docs/src/app/pages/landing/landing-page.component.ts
+++ b/apps/docs/src/app/pages/landing/landing-page.component.ts
@@ -1,6 +1,5 @@
 import { Component, ElementRef, HostListener, ViewChild } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { trigger, state, style, animate, transition } from '@angular/animations';
 import { ERoutes } from '../../shared/types';
 
 @Component({
@@ -8,46 +7,29 @@ import { ERoutes } from '../../shared/types';
 	selector: 'landing-page',
 	templateUrl: 'landing-page.component.html',
 	styleUrl: 'landing-page.component.scss',
-	animations: [
-		trigger('slideIn', [
-			state(
-				'hide',
-				style({
-					clipPath: 'inset(0 100% 0 0)',
-				})
-			),
-			state(
-				'show',
-				style({
-					clipPath: 'inset(0 0 0 0)',
-				})
-			),
-			transition('hide => show', [animate('1s 100ms ease-in-out')]),
-		]),
-	],
 })
 export class LandingPageComponent {
 	public routes: typeof ERoutes = ERoutes;
 
-	clipQuoteLine = true;
-	clipPhotoLine = true;
+	clipQuoteLine = false;
+	clipPhotoLine = false;
 
 	@ViewChild('quote', { static: false }) private quote: ElementRef<HTMLDivElement> | undefined;
 	@ViewChild('photo', { static: false }) private photo: ElementRef<HTMLDivElement> | undefined;
 
 	@HostListener('window:scroll', ['$event'])
 	isScrolledIntoView() {
-		if (this.quote && this.clipQuoteLine) {
+		if (this.quote && !this.clipQuoteLine) {
 			const rect = this.quote.nativeElement.getBoundingClientRect();
 			const topShown = rect.top >= 0;
 			const bottomShown = rect.bottom <= window.innerHeight;
-			this.clipQuoteLine = !(topShown && bottomShown);
+			this.clipQuoteLine = topShown && bottomShown;
 		}
-		if (this.photo && this.clipPhotoLine) {
+		if (this.photo && !this.clipPhotoLine) {
 			const rect = this.photo.nativeElement.getBoundingClientRect();
 			const topShown = rect.top >= 0;
 			const bottomShown = rect.bottom <= window.innerHeight;
-			this.clipPhotoLine = !(topShown && bottomShown);
+			this.clipPhotoLine = topShown && bottomShown;
 		}
 	}
 }


### PR DESCRIPTION
**Description**
This update addresses two bugs for the landing page of the documentation:

- H2 was not aligned to the right on firefox and safari.
- The line animation would not fade for one state to the other, it jumped straight to the end state on safari.

