### PR TITLE
feat(ngx-i18n): add the option to cache bust the translation files using the root config

### DIFF
--- a/apps/i18n-test/src/main.ts
+++ b/apps/i18n-test/src/main.ts
@@ -11,6 +11,7 @@ bootstrapApplication(AppComponent, {
 		importNgxI18nProviders({
 			defaultLanguage: 'nl',
 			defaultAssetPaths: ['./assets/shared/'],
+			cacheBust: '1.0.0',
 		}),
 		provideHttpClient(withInterceptorsFromDi()),
 	],

--- a/libs/angular/i18n/src/lib/i18n.types.ts
+++ b/libs/angular/i18n/src/lib/i18n.types.ts
@@ -3,4 +3,18 @@ export interface NgxI18nConfiguration {
 	availableLanguages?: string[];
 	defaultAssetPaths: string[];
 	languageRouteParam?: string;
+	/**
+	 * The cache busting parameter to append to the translation file requests.
+	 * This can be useful when you want to force the browser to fetch the latest
+	 * version of the translation files by appending this value to the `v` query
+	 * parameter.
+	 *
+	 * When not provided, no query parameter will be added to the request.
+	 *
+	 * @example
+	 * `?v=1` when `cacheBust: '' + 1`
+	 * `?v=1.0.0` when `cacheBust: '1.0.0'`
+	 * `?v=1743428073628` when `cacheBust: String(Date.now())`
+	 */
+	cacheBust?: string;
 }

--- a/libs/angular/i18n/src/lib/loader/multi-translation/multi-translation.loader.ts
+++ b/libs/angular/i18n/src/lib/loader/multi-translation/multi-translation.loader.ts
@@ -6,10 +6,17 @@ import { forkJoin, Observable, of } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 
 import { NgxI18nLoadingService } from '../../services';
+import { NgxI18nConfiguration } from '../../i18n.types';
+import { NgxI18nConfigurationToken } from '../../tokens';
 
 export class NgxI18nMultiTranslationHttpLoader implements TranslateLoader {
 	private readonly translationLoadingService: NgxI18nLoadingService =
 		inject(NgxI18nLoadingService);
+
+	/**
+	 * The configuration for the NgxI18nModule.
+	 */
+	private readonly config: NgxI18nConfiguration = inject(NgxI18nConfigurationToken);
 
 	constructor(
 		private readonly httpBackend: HttpBackend,
@@ -37,7 +44,9 @@ export class NgxI18nMultiTranslationHttpLoader implements TranslateLoader {
 				});
 			} else {
 				// Iben: If the translations aren't available in the store, we fetch them from the server
-				const fetchPath = `${path}${lang}.json`;
+				// Wouter: When provided, add a cache busting param so that each request is fetched from the server instead of the browser cache
+				const fetchPath = `${path}${lang}.json${this.config.cacheBust ? '?v=' + this.config.cacheBust : ''}`;
+
 				return new HttpClient(this.httpBackend).get(fetchPath).pipe(
 					// Iben: Map this to an object so we can track which results corresponds with which path
 					map((translations) => {


### PR DESCRIPTION
**Description**
This PR allows for a cache busting parameter to be appended to each translation file request. This allows the user more control over the private (browser) cache behaviour.
This can for example be paired with an automated build pipelines to always bust the cache when deploying a new version of the files. 

**Requirements**

- [x] Correct label have been assigned
- [x] Project has been assigned
- [x] Milestone has been (created/)assigned

**Attachments**


https://github.com/user-attachments/assets/a1df6645-fe83-4802-9b09-32d791a14a61




