### PR TITLE
Fix: correct next page logic in calculateNextPage utility

### DIFF
--- a/libs/javascript/pagination/src/hal-format.helper.spec.ts
+++ b/libs/javascript/pagination/src/hal-format.helper.spec.ts
@@ -51,6 +51,14 @@ describe('HAL Format Tools', () => {
 		it('should return 1 if there is only one page', () => {
 			expect(calculateNextPage(1, 1)).toBe(1);
 		});
+	
+		it('should handle invalid input gracefully: currentPage > totalPages', () => {
+			expect(calculateNextPage(3, 5)).toBe(3);
+		});
+
+		it('should handle 0 as current page', () => {
+			expect(calculateNextPage(5, 0)).toBe(1);
+		});
 	});
 
 	describe('createHalLinks', () => {

--- a/libs/javascript/pagination/src/hal-format.helper.ts
+++ b/libs/javascript/pagination/src/hal-format.helper.ts
@@ -41,8 +41,9 @@ export function calculatePagination(
  * @param currentPage
  */
 export function calculateNextPage(totalPages: number, currentPage: number): number {
-	return currentPage === totalPages ? currentPage : currentPage + 1;
+	return currentPage < totalPages ? currentPage + 1 : currentPage;
 }
+
 
 /**
  * Create the HAL-format links to self, first-, last- & next-page.


### PR DESCRIPTION
Fixed an issue in `calculateNextPage` where it incorrectly allowed next page even if currentPage > totalPages. Now it returns the next page only if more pages exist. This improves the accuracy of HAL pagination and prevents broken next links.
