### PR TITLE
feat(ngx-table): add row and index context to the dynamic open row state template

### DIFF
--- a/libs/angular/table/src/lib/table/ngx-table.component.html
+++ b/libs/angular/table/src/lib/table/ngx-table.component.html
@@ -81,6 +81,8 @@
 							showDetailRow === 'always' ||
 							(showDetailRow === 'on-single-item' && data?.length === 1) ||
 							openRows.has(index),
+						row: row,
+						index: index,
 					}"
 				>
 				</ng-template>


### PR DESCRIPTION
**Description**
The `openRowStateTmpl` now also provides the row and index context to the custom `openRowStateTemplate` `contentChild` selector.
This is useful when rendering additional context in a certain row, like a `new` row indicator.

**Requirements**

- [x] Correct label have been assigned
- [x] Project has been assigned
- [x] Milestone has been (created/)assigned
