### PR TITLE
feat(ngx-table): add an optional context row to the table

### DIFF
--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-one/context-row-one.demo.component.html
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-one/context-row-one.demo.component.html
@@ -1,0 +1,12 @@
+<ngx-table
+	[data]="[
+		{ name: 'World', firstName: 'Hello', active: true },
+		{ name: 'Tools', firstName: 'NGX', active: false },
+	]"
+	[columns]="['name', 'firstName']"
+	[contextRowKeys]="['active']"
+>
+	<ng-template #contextRowTmpl let-row>
+		{{ row | json }}
+	</ng-template>
+</ngx-table>

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-one/context-row-one.demo.component.ts
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-one/context-row-one.demo.component.ts
@@ -1,0 +1,10 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { NgxTable } from '@ngx/table';
+
+@Component({
+	imports: [CommonModule, NgxTable],
+	selector: 'context-row-one-demo',
+	templateUrl: './context-row-one.demo.component.html',
+})
+export class ContextRowOneDemoComponent {}

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-three/context-row-three.demo.component.html
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-three/context-row-three.demo.component.html
@@ -1,0 +1,12 @@
+<ngx-table
+	[data]="[
+		{ name: 'World', firstName: 'Hello', favorite: true, favoriteSince: '2023-01-01' },
+		{ name: 'Tools', firstName: 'NGX', favorite: false },
+		{ name: 'Angular', firstName: 'Framework', favorite: true, favoriteSince: '2022-05-15' },
+	]"
+	[columns]="['name', 'firstName']"
+	[contextRowKeys]="['favorite']"
+>
+	<ng-template #contextRowTmpl let-row> Favorite since {{ row.favoriteSince }} </ng-template>
+	<ng-template #detailRowTmpl let-row> {{ row | json }} </ng-template>
+</ngx-table>

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-three/context-row-three.demo.component.scss
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-three/context-row-three.demo.component.scss
@@ -1,0 +1,67 @@
+$fav-border: 1px solid gold;
+
+::ng-deep {
+	.ngx-table {
+		border: none !important;
+	}
+	.cdk-header-row * {
+		border: none !important;
+		text-align: left;
+		text-transform: capitalize;
+	}
+
+	.ngx-table-row-cell {
+		border: none !important;
+	}
+
+	.ngx-table-detail-cell {
+		background-color: rgb(250, 250, 250);
+		border: none !important;
+	}
+
+	.ngx-table-context-key--favorite {
+		background-color: rgb(255, 247, 199);
+
+		> * {
+			padding: 3px 10px !important;
+			border: $fav-border !important;
+			border-bottom: none !important;
+			font-style: italic;
+			font-size: 0.8em;
+
+			&::before {
+				content: '★';
+				color: darkgoldenrod;
+				margin-right: 5px;
+			}
+		}
+
+		+ .ngx-table-row {
+			.ngx-table-row-cell {
+				border-bottom: $fav-border !important;
+
+				&:first-child {
+					border-left: $fav-border !important;
+				}
+
+				&:last-child {
+					border-right: $fav-border !important;
+				}
+			}
+
+			&:has(+ .ngx-table-detail-row-open) {
+				.ngx-table-row-cell {
+					border-bottom: none !important;
+				}
+			}
+
+			+ .ngx-table-detail-row-open {
+				.ngx-table-detail-cell {
+					border-left: $fav-border !important;
+					border-right: $fav-border !important;
+					border-bottom: $fav-border !important;
+				}
+			}
+		}
+	}
+}

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-three/context-row-three.demo.component.ts
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-three/context-row-three.demo.component.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { NgxTable } from '@ngx/table';
+
+@Component({
+	imports: [CommonModule, NgxTable],
+	selector: 'context-row-three-demo',
+	templateUrl: './context-row-three.demo.component.html',
+	styleUrl: './context-row-three.demo.component.scss',
+})
+export class ContextRowThreeDemoComponent {}

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-two/context-row-two.demo.component.html
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-two/context-row-two.demo.component.html
@@ -1,0 +1,12 @@
+<ngx-table
+	[data]="[
+		{ name: 'World', firstName: 'Hello', active: true },
+		{ name: 'Tools', firstName: 'NGX', active: false },
+	]"
+	[columns]="['name', 'firstName']"
+	[contextRowKeys]="['name', 'active']"
+>
+	<ng-template #contextRowTmpl let-row>
+		{{ row | json }}
+	</ng-template>
+</ngx-table>

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-two/context-row-two.demo.component.ts
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/context-row-two/context-row-two.demo.component.ts
@@ -1,0 +1,10 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { NgxTable } from '@ngx/table';
+
+@Component({
+	imports: [CommonModule, NgxTable],
+	selector: 'context-row-two-demo',
+	templateUrl: './context-row-two.demo.component.html',
+})
+export class ContextRowTwoDemoComponent {}

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/index.ts
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/demos/index.ts
@@ -1,0 +1,3 @@
+export * from './context-row-one/context-row-one.demo.component';
+export * from './context-row-two/context-row-two.demo.component';
+export * from './context-row-three/context-row-three.demo.component';

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/index.md
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/index.md
@@ -1,0 +1,37 @@
+---
+keyword: ContextRowPage
+---
+
+`ngx-table` provides a built-in way to add context rows to your table rows. This can be done by providing the `#contextRowTmpl` template as a `ContentChild` of the `NgxTable`.
+
+## Example use case
+
+Since the use of this component is not easily described, below is an example of when a context row could be useful. Let's say you want to visualize if and when a certain data entry has been favorited, the context row can be useful.
+_Continue reading below for the (property) explanation._
+
+{{ NgDocActions.demo("ContextRowThreeDemoComponent") }}
+
+## Explanation
+
+> **Note:** It is very important to be aware that this row does as its name suggests: it allows for additional context. It should not be used to add or define data of the row itself. This context row always has the `role="none"` aria tag. This means any and all content defined in this row gets excluded from the accessibility tree. Elements that are defined within this row that have a tabindex greater than or equal to 0 (and are therefor focusable) _are_ included in the accessibility tree. This means that you may include buttons and links inside this row. For more information and what not to define in this context row, please visit the official ARIA docs: https://w3c.github.io/aria/#none.
+
+Once a context row is provided, the row does not automatically become visible. We need to use an Input to handle the behavior of the table. By defining the `contextRowKeys` input to a non-empty array, the attributes of the `data` are checked for a possible match. If at least one key of the data the row consists of matches a value of the `contextRowKeys`, that row will get a context row. If no key matches, the row will still get a context row, but the class will be `ngx-context-row`. This is the same way that detail views are rendered when they are not expanded.
+
+From the moment that the `#contextRowTmpl` has been defined, every main row will get a corresponding context row. It is set to `display: none` as long as it is empty, and it shall remain empty as long as the above condition is not met. Be cautious of applying styles to the `ngx-context-row` class.
+
+{{ NgDocActions.demo("ContextRowOneDemoComponent") }}
+
+Be cautious of applying styles to the `ngx-context-row` class, since hidden context rows also have this class. You can modify how all visible context rows look by applying styles to the `ngx-table-context-row-open` class. In the above example, only one key was provided to the table via the `contextRowKeys`. This resulted in the row with the `active: true` to also be assigned the `ngx-table-context-key--active` modifier class.
+
+In the example below, the `name` key of the data also gets taken into account. This results in more than one modifier to be applied to the context row that also has the `active` property set to `true`. The order in which the classes are applied to the element, is the same order in which the array values are provided to the `contextRowKeys` input.
+
+Note the classes in the example below using the DevTools. The first row should get the following classes (aside from the by-Angular-injected classes):
+
+1. `cdk-row`
+1. `ngx-table-context-row`
+1. `ngx-table-context-row-open`
+1. `ngx-table-row-first`
+1. `ngx-table-context-key--name`
+1. `ngx-table-context-key--active`
+
+{{ NgDocActions.demo("ContextRowTwoDemoComponent") }}

--- a/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/ng-doc.page.ts
+++ b/apps/docs/src/app/pages/docs/angular/table/implementation/context-row/ng-doc.page.ts
@@ -1,0 +1,17 @@
+import { NgDocPage } from '@ng-doc/core';
+import { TableImplementationCategory } from '../../../../../../categories/angular';
+import {
+	ContextRowOneDemoComponent,
+	ContextRowTwoDemoComponent,
+	ContextRowThreeDemoComponent,
+} from './demos';
+
+const ContextRowPage: NgDocPage = {
+	title: `Context row`,
+	mdFile: './index.md',
+	category: TableImplementationCategory,
+	order: 1,
+	demos: { ContextRowOneDemoComponent, ContextRowTwoDemoComponent, ContextRowThreeDemoComponent },
+};
+
+export default ContextRowPage;

--- a/apps/table-test/src/app/app.component.html
+++ b/apps/table-test/src/app/app.component.html
@@ -21,6 +21,7 @@
 		[selectable]="true"
 		[currentSorting]="currentSort"
 		[resetFormOnNewData]="false"
+		[contextRowKeys]="contextRowKeys"
 		(rowClicked)="rowEmitted($event)"
 	>
 		<ng-template #radioTmpl let-control let-row="row" let-index="index">
@@ -36,6 +37,16 @@
 			<ng-template #detailRowTmpl let-row let-index="index">
 				{{ row | json }}
 				{{ index }}
+			</ng-template>
+		}
+		@if (showContext) {
+			<ng-template #contextRowTmpl let-row let-index="index">
+				The item below has
+				<code
+					>{{ row.active ? 'active' : ''
+					}}{{ row.someKey ? (row.active ? ' and someKey' : 'someKey') : '' }}</code
+				>
+				special class.
 			</ng-template>
 		}
 
@@ -70,5 +81,7 @@
 </app-wrapper>
 
 <button (click)="setFormValue()">Set form value</button>
+<button (click)="toggleContextView()">Toggle context row</button>
 <button (click)="toggleDetailView()">Toggle detail row</button>
 <button (click)="toggleDataSet()">Toggle dataset</button>
+<button (click)="toggleContextKeysSet()">Toggle context set</button>

--- a/apps/table-test/src/app/app.component.scss
+++ b/apps/table-test/src/app/app.component.scss
@@ -7,14 +7,26 @@
 		color: darkred;
 	}
 }
+code {
+	background-color: #f0f0f0;
+	padding: 2px 5px;
+	border-radius: 3px;
+	font-family: monospace;
+}
 
 ::ng-deep {
 	.ngx-table-row-selected {
 		outline: 2px dashed red;
 	}
 
+	.ngx-table-context-row {
+		padding: 3px !important;
+		font-size: 0.9em;
+		font-style: italic;
+	}
+
 	.ngx-table-row-first {
-		background-color: lightblue;
+		color: rgb(60, 164, 58);
 
 		> :first-child {
 			border-top-left-radius: 10px;
@@ -33,6 +45,20 @@
 
 		> :last-child {
 			border-bottom-right-radius: 10px;
+		}
+	}
+
+	.ngx-table-context-key {
+		&--active,
+		&--active + .ngx-table-row,
+		&--active + .ngx-table-row + .ngx-table-detail-row {
+			background-color: rgb(241, 241, 193);
+		}
+
+		&--someKey,
+		&--someKey + .ngx-table-row,
+		&--someKey + .ngx-table-row + .ngx-table-detail-row {
+			background-color: rgb(206, 250, 206);
 		}
 	}
 }

--- a/apps/table-test/src/app/app.component.ts
+++ b/apps/table-test/src/app/app.component.ts
@@ -31,6 +31,7 @@ export class AppComponent {
 			hello: 'world',
 			amount: 37,
 			date: '12/02/2023',
+			someKey: true,
 		},
 		{
 			name: 'Hyperdrive',
@@ -40,6 +41,7 @@ export class AppComponent {
 			hello: 'world',
 			amount: 5000,
 			date: '12/02/2023',
+			someKey: false,
 		},
 		{
 			name: 'Hyperdrive',
@@ -49,6 +51,7 @@ export class AppComponent {
 			hello: 'world',
 			amount: 5000,
 			date: '12/02/2023',
+			someKey: true,
 		},
 	];
 
@@ -61,6 +64,7 @@ export class AppComponent {
 			hello: 'world',
 			amount: 0.5,
 			date: '12/02/2023',
+			someKey: false,
 		},
 	];
 
@@ -68,7 +72,11 @@ export class AppComponent {
 
 	public readonly columns = ['firstName', 'name', 'date', 'button', 'amount', 'active'];
 
+	public contextRowKeys = undefined;
+
 	public showDetail = true;
+
+	public showContext = true;
 
 	public form = new FormControl();
 
@@ -82,6 +90,10 @@ export class AppComponent {
 
 	public toggleDetailView() {
 		this.showDetail = !this.showDetail;
+	}
+
+	public toggleContextView() {
+		this.showContext = !this.showContext;
 	}
 
 	public toggleDataSet() {
@@ -100,5 +112,9 @@ export class AppComponent {
 
 	public sort(event: NgxTableSortEvent) {
 		this.currentSort = event;
+	}
+
+	public toggleContextKeysSet(): void {
+		this.contextRowKeys = this.contextRowKeys ? null : ['someKey', 'active'];
 	}
 }

--- a/apps/table-test/src/main.ts
+++ b/apps/table-test/src/main.ts
@@ -2,18 +2,19 @@ import { importProvidersFrom } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
-import { NgxTableConfigToken } from '@ngx/table';
+import { NgxTableConfig, NgxTableConfigToken } from '@ngx/table';
 
 bootstrapApplication(AppComponent, {
 	providers: [
 		importProvidersFrom(BrowserModule, ReactiveFormsModule),
 		{
 			provide: NgxTableConfigToken,
-			useValue: {
+			useValue: <NgxTableConfig>{
 				showDetailRow: 'on-single-item',
 				showOpenRowState: true,
 				emitValueOnSingleItem: true,
 				hideHeaderWhen: ['when-loading'],
+				contextRowKeys: ['active'],
 			},
 		},
 	],

--- a/libs/angular/table/src/lib/table/ngx-table.component.html
+++ b/libs/angular/table/src/lib/table/ngx-table.component.html
@@ -10,6 +10,9 @@
 	[attr.aria-multiselectable]="selectableType === 'checkbox'"
 	[dataSource]="!loading ? data : []"
 >
+	<!-- ---------------------- -->
+	<!-- TABLE CELL DEFINITIONS -->
+	<!-- ---------------------- -->
 	@if (selectable) {
 		<ng-container cdkColumnDef="ngxTableSelectColumn">
 			<th
@@ -31,16 +34,16 @@
 				}
 			</th>
 			<td
-				*cdkCellDef="let row; let index = dataIndex"
+				*cdkCellDef="let row; let dataIndex = dataIndex"
 				class="ngx-table-cell ngx-table-row-cell ngx-table-selectable-cell"
 				[ngxTreeGridCell]="0"
-				[ngxTreeGridCellRow]="index"
+				[ngxTreeGridCellRow]="dataIndex"
 			>
 				@if (
 					selectableType === 'radio' ||
 						(selectableType === 'checkbox' &&
 							rowsFormGroup.controls[
-								this.selectableKey ? row[selectableKey] : index
+								this.selectableKey ? row[selectableKey] : dataIndex
 							]);
 					as control
 				) {
@@ -51,7 +54,7 @@
 						[ngTemplateOutletContext]="{
 							$implicit: control,
 							row: row,
-							index: index,
+							index: dataIndex,
 						}"
 					>
 					</ng-template>
@@ -68,11 +71,11 @@
 		<ng-container cdkColumnDef="ngxOpenRowStateColumn">
 			<th *cdkHeaderCellDef class="ngx-table-cell ngx-table-header-cell" cdk-header-cell></th>
 			<td
-				*cdkCellDef="let row; let index = dataIndex"
+				*cdkCellDef="let row; let dataIndex = dataIndex"
 				class="ngx-table-cell ngx-table-row-cell ngx-table-open-row-state-cell"
 				[ngxTreeGridCell]="selectable ? columns.length + 1 : columns.length + 2"
-				[ngxTreeGridCellRow]="index"
-				(click)="handleRowClicked(row, index)"
+				[ngxTreeGridCellRow]="dataIndex"
+				(click)="handleRowClicked(row, dataIndex)"
 			>
 				<ng-template
 					[ngTemplateOutlet]="openRowStateTemplate || defaultOpenRowStateTmpl"
@@ -80,9 +83,9 @@
 						$implicit:
 							showDetailRow === 'always' ||
 							(showDetailRow === 'on-single-item' && data?.length === 1) ||
-							openRows.has(index),
+							openRows.has(dataIndex),
 						row: row,
-						index: index,
+						index: dataIndex,
 					}"
 				>
 				</ng-template>
@@ -162,7 +165,7 @@
 				}
 			</th>
 			<td
-				*cdkCellDef="let row; let index = dataIndex"
+				*cdkCellDef="let row; let dataIndex = dataIndex"
 				cdk-cell
 				[ngClass]="[
 					'ngx-table-cell',
@@ -170,11 +173,11 @@
 					tableCellTemplateRecord()[column]?.cellClass || '',
 				]"
 				[ngxTreeGridCell]="selectable ? columnIndex + 1 : columnIndex"
-				[ngxTreeGridCellRow]="index"
+				[ngxTreeGridCellRow]="dataIndex"
 				[attr.data-cy]="tableCypressRecord()[column]?.cell || ''"
 				[attr.role]="detailRowTemplate ? 'gridcell' : 'cell'"
 				[attr.aria-readonly]="!editableTableCellRecord()[column]"
-				(click)="handleRowClicked(row, index)"
+				(click)="handleRowClicked(row, dataIndex)"
 			>
 				@if (tableCellTemplateRecord()[column]?.cellTemplate) {
 					<ng-template
@@ -182,11 +185,11 @@
 						[ngTemplateOutletContext]="{
 							$implicit: row[column],
 							row: row,
-							index: index,
+							index: dataIndex,
 							isRowOpen:
 								showDetailRow === 'always' ||
 								(showDetailRow === 'on-single-item' && data?.length === 1) ||
-								openRows.has(index),
+								openRows.has(dataIndex),
 						}"
 					>
 					</ng-template>
@@ -209,26 +212,66 @@
 			</td>
 		</ng-container>
 	}
+	@if (contextRowTemplate) {
+		<ng-container cdkColumnDef="ngxTableContextColumn">
+			<td
+				*cdkCellDef="let row; let dataIndex = dataIndex"
+				class="ngx-table-cell ngx-table-context-cell"
+				cdk-cell
+				[attr.colspan]="definedColumns().length"
+			>
+				<ng-template
+					[ngTemplateOutlet]="contextRowTmpl"
+					[ngTemplateOutletContext]="{ $implicit: row, index: dataIndex }"
+				>
+				</ng-template>
+			</td>
+		</ng-container>
+	}
 	@if (detailRowTemplate) {
 		<ng-container cdkColumnDef="ngxTableDetailColumn">
 			<td
-				*cdkCellDef="let row; let index = dataIndex"
+				*cdkCellDef="let row; let dataIndex = dataIndex"
 				class="ngx-table-cell ngx-table-detail-cell"
 				cdk-cell
 				[attr.colspan]="definedColumns().length"
 			>
 				<ng-template
 					[ngTemplateOutlet]="detailRowTmpl"
-					[ngTemplateOutletContext]="{ $implicit: row, index: index }"
+					[ngTemplateOutletContext]="{ $implicit: row, index: dataIndex }"
 				>
 				</ng-template>
 			</td>
 		</ng-container>
 	}
+	<!-- --------------------- -->
+	<!-- TABLE ROW DEFINITIONS -->
+	<!-- --------------------- -->
 	@if ({ isLoading: loading, isEmpty: data?.length === 0 } | ngxTableShowHeader: hideHeaderWhen) {
 		<tr *cdkHeaderRowDef="definedColumns()" cdk-header-row></tr>
 	}
 	@if (data) {
+		@if (contextRowTemplate) {
+			<!-- Wouter: A context row can be used to display additional information about a row, but it should not contain any data used to define the main row.
+			 This context row gets stripped, as per the docs, of its accessibility features and be excluded from the accessibility tree.
+			 DOCS: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/presentation_role -->
+			<tr
+				*cdkRowDef="
+					let row;
+					columns: ['ngxTableContextColumn'];
+					let first = first;
+					let dataIndex = dataIndex
+				"
+				class="ngx-table-context-row"
+				cdk-row
+				role="none"
+				[ngClass]="[
+					first && contextRowClasses?.[dataIndex] ? 'ngx-table-row-first' : '',
+					contextRowClasses?.[dataIndex] ?? '',
+				]"
+				[class.ngx-table-context-row-open]="contextRowClasses?.[dataIndex]"
+			></tr>
+		}
 		<!-- Wouter: An explanation for the ngx-table-row-last class calculation:
 			- If there is a detail row template, we only want to apply the class if the row is not open. Additionally, it must be the second-to-last
 				rendered row. This is because the length of the data and the indexes are already off by one, and we want the second-to-last row, so minus another one.
@@ -237,7 +280,7 @@
 			*cdkRowDef="
 				let row;
 				columns: definedColumns();
-				let rowIndex = dataIndex;
+				let dataIndex = dataIndex;
 				let last = last;
 				let first = first;
 				let count = count;
@@ -251,9 +294,13 @@
 				'ngx-table-row',
 				rowClass || '',
 				row[highlightKey] ? 'ngx-table-row-highlight' : '',
-				first ? 'ngx-table-row-first' : '',
+				first
+					? 'ngx-table-row-first'
+					: !contextRowClasses[dataIndex] && dataIndex === 0
+						? 'ngx-table-row-first'
+						: '',
 				detailRowTemplate
-					? openRows.has(rowIndex)
+					? openRows.has(dataIndex)
 						? ''
 						: renderIndex === count - 2
 							? 'ngx-table-row-last'
@@ -262,30 +309,30 @@
 						? 'ngx-table-row-last'
 						: '',
 			]"
-			[class.ngx-table-row-odd]="rowIndex % 2 !== 0"
-			[class.ngx-table-row-even]="rowIndex % 2 === 0"
+			[class.ngx-table-row-odd]="dataIndex % 2 !== 0"
+			[class.ngx-table-row-even]="dataIndex % 2 === 0"
 			[class.ngx-table-row-selected]="
 				showSelectedOpenRow &&
-				(selectedRow === rowIndex ||
+				(selectedRow === dataIndex ||
 					(showDetailRow === 'on-single-item' && data?.length === 1))
 			"
-			[ngxTreeGridRow]="rowIndex"
+			[ngxTreeGridRow]="dataIndex"
 			[ngxTreeGridRowSelectable]="selectable"
-			[ngxTreeGridRowExpanded]="openRows.has(rowIndex)"
+			[ngxTreeGridRowExpanded]="openRows.has(dataIndex)"
 			[attr.aria-selected]="
 				rowsFormGroup.get(
-					selectableKey ? '' + data[rowIndex][selectableKey] : '' + rowIndex
+					selectableKey ? '' + data[dataIndex][selectableKey] : '' + dataIndex
 				)?.value
 			"
-			(ngxTreeGridRowSelectRow)="selectRow(rowIndex)"
-			(ngxTreeGridRowExpandRow)="handleRowState(rowIndex, $event ? 'open' : 'close')"
-			(keydown.enter)="handleRowClicked(row, rowIndex)"
+			(ngxTreeGridRowSelectRow)="selectRow(dataIndex)"
+			(ngxTreeGridRowExpandRow)="handleRowState(dataIndex, $event ? 'open' : 'close')"
+			(keydown.enter)="handleRowClicked(row, dataIndex)"
 		></tr>
 		@if (detailRowTemplate) {
 			<tr
 				*cdkRowDef="
 					let row;
-					let index = dataIndex;
+					let dataIndex = dataIndex;
 					columns: ['ngxTableDetailColumn'];
 					let last = last
 				"
@@ -298,12 +345,12 @@
 						last &&
 						(showDetailRow === 'always' ||
 							(showDetailRow === 'on-single-item' && data?.length === 1) ||
-							openRows.has(index)),
+							openRows.has(dataIndex)),
 				}"
 				[class.ngx-table-detail-row-open]="
 					showDetailRow === 'always' ||
 					(showDetailRow === 'on-single-item' && data?.length === 1) ||
-					openRows.has(index)
+					openRows.has(dataIndex)
 				"
 			></tr>
 		}
@@ -340,6 +387,14 @@
 		>
 		</ng-template>
 	}
+</ng-template>
+
+<ng-template #contextRowTmpl let-row let-index="index">
+	<ng-template
+		[ngTemplateOutlet]="contextRowTemplate"
+		[ngTemplateOutletContext]="{ $implicit: row, index }"
+	>
+	</ng-template>
 </ng-template>
 
 <ng-template #checkboxTmpl let-control let-row="row" let-index="index">

--- a/libs/angular/table/src/lib/table/ngx-table.component.scss
+++ b/libs/angular/table/src/lib/table/ngx-table.component.scss
@@ -74,4 +74,10 @@
 			display: none;
 		}
 	}
+
+	.ngx-table-context-row {
+		&:not(.ngx-table-context-row-open) {
+			display: none;
+		}
+	}
 }

--- a/libs/angular/table/src/lib/token/ngx-table-config.token.ts
+++ b/libs/angular/table/src/lib/token/ngx-table-config.token.ts
@@ -10,14 +10,15 @@ export type ShowDetailRowOption = 'always' | 'on-click' | 'on-single-item';
 /**
  * A configuration we can provide to set properties of the table globally
  *
- * showDetailRow - Defines the default open behavior of detail rows. 'always' will open all rows by default, 'on-click' will only open them on click, 'on-single-item' will open the row on click and when there's only one item in the table.
- * ngxTableClass - A default class that will be set on the ngx-table component itself
- * showOpenRowState - Defines whether we always want to show the open-row state indicator for each table.
- * allowMultipleRowsOpen - Defines whether multiple rows can be open at once.
- * showOpenRowState - Defines whether we always want to show the open-row state indicator for each table.
- * showSelectedOpenRow - Defines whether we want a class to be added to the currently opened row
- * emitValueOnSingleItem - Defines whether we want to emit the rowClicked when there's only one item in the table and the showDetailRow is set to 'on-single-item'
- * hideHeaderWhen - Defines whether we want to show the header when the table is empty or loading
+ * - `showDetailRow` - Defines the default open behavior of detail rows. 'always' will open all rows by default, 'on-click' will only open them on click, 'on-single-item' will open the row on click and when there's only one item in the table.
+ * - `ngxTableClass` - A default class that will be set on the ngx-table component itself
+ * - `showOpenRowState` - Defines whether we always want to show the open-row state indicator for each table.
+ * - `allowMultipleRowsOpen` - Defines whether multiple rows can be open at once.
+ * - `showOpenRowState` - Defines whether we always want to show the open-row state indicator for each table.
+ * - `showSelectedOpenRow` - Defines whether we want a class to be added to the currently opened row
+ * - `emitValueOnSingleItem` - Defines whether we want to emit the rowClicked when there's only one item in the table and the showDetailRow is set to 'on-single-item'
+ * - `hideHeaderWhen` - Defines whether we want to show the header when the table is empty or loading
+ * - `contextRowKeys` - Defines the keys that should be used to determine the context row classes and whether a context row should be shown.
  */
 export interface NgxTableConfig {
 	showDetailRow?: ShowDetailRowOption;
@@ -28,6 +29,7 @@ export interface NgxTableConfig {
 	showSelectedOpenRow?: boolean;
 	emitValueOnSingleItem?: boolean;
 	hideHeaderWhen?: HideHeaderRowOption;
+	contextRowKeys?: string[];
 }
 
 export const NgxTableConfigToken = new InjectionToken<NgxTableConfig>('NgxTableConfig');


### PR DESCRIPTION
**Description**
The table has gotten an upgrade!

We required a context row for the VLAIO project and saw no other practical way than to add it as a feature to the table.
In short: a context row is a row that adds no accessibility addition, will always be interpreted as if it was a `span` element. The text in it will be read, buttons and links will have their persisting accessibility features, and an additional row is added to the table. This row allows for a more customisable experience, like the one in the styled example of the docs. (added as PDF to the attachments)

It uses an input and is therefore toggleable. It uses keys defined in the data object array to evaluate whether a row requires an additional context header.

**Requirements**

- [x] Correct label have been assigned
- [x] Project has been assigned
- [x] Milestone has been (created/)assigned

**PDF of the docs:** 
[context-row-docs.pdf](https://github.com/user-attachments/files/21513717/context-row-docs.pdf)

**Attachments**

https://github.com/user-attachments/assets/01910784-d42c-48da-aa4e-76e6e879cf7d

